### PR TITLE
BndtoolsRuntimeController: added support to utilize existing OSGi Http Service instead of integrated HTTP server.

### DIFF
--- a/bndtools.runtime.controller/bnd.bnd
+++ b/bndtools.runtime.controller/bnd.bnd
@@ -10,5 +10,8 @@ Private-Package: org.bndtools.runtime.controller.internal
 -runfw: org.apache.felix.framework
 Export-Package: org.bndtools.runtime.controller
 Import-Package: org.osgi.service.log;resolution:=optional,\
+ org.osgi.service.http;resolution:=optional,\
+ javax.servlet;resolution:=optional,\
+ javax.servlet.http;resolution:=optional,\
 	*
-Bundle-Version: 0.0.1
+Bundle-Version: 0.0.2

--- a/bndtools.runtime.controller/src/org/bndtools/runtime/controller/internal/Activator.java
+++ b/bndtools.runtime.controller/src/org/bndtools/runtime/controller/internal/Activator.java
@@ -11,6 +11,11 @@ public class Activator implements BundleActivator {
 
     private static final int DEFAULT_NANO_PORT = 2604;
 	private static final String PROP_NANO_PORT = "bndtools.runtime.controller.nanoPort";
+	
+	/**
+	 * If enabled, this will cause the runtime controller to use an existing HTTP Service rather than the internal server.
+	 */
+	private static final String PROP_USE_HTTP_SERVICE = "bndtools.runtime.controller.useHttpService";
     
     // Handler Prefixes
     private static final String PREFIX_BUNDLES = "bundles";
@@ -35,13 +40,20 @@ public class Activator implements BundleActivator {
 		}
 
 		// Setup the server
-		String nanoPortStr = context.getProperty(PROP_NANO_PORT);
-		if (nanoPortStr != null) {
-			int nanoPort = Integer.parseInt(nanoPortStr);
-			server = new NanoServer(nanoPort, log);
+		IServer server = null;
+		if (context.getProperty(PROP_USE_HTTP_SERVICE) != null) {
+			// HttpService server
+		    server = new HttpServiceServer(context, log);
 		} else {
-			server = new NanoServer(DEFAULT_NANO_PORT, log);
-		} // TODO: additional server types e.g. HttpServic
+			// NanoServer server
+    		String nanoPortStr = context.getProperty(PROP_NANO_PORT);
+    		if (nanoPortStr != null) {
+    			int nanoPort = Integer.parseInt(nanoPortStr);
+    			server = new NanoServer(nanoPort, log);
+    		} else {
+    			server = new NanoServer(DEFAULT_NANO_PORT, log);
+    		} 
+		}
 
         server.registerHandler(PREFIX_BUNDLES, new BundlesHandler(context, log));
         server.registerHandler(PREFIX_PACKAGES, new PackagesHandler(context, pkgAdminTracker));

--- a/bndtools.runtime.controller/src/org/bndtools/runtime/controller/internal/HandlerServletAdapter.java
+++ b/bndtools.runtime.controller/src/org/bndtools/runtime/controller/internal/HandlerServletAdapter.java
@@ -1,0 +1,134 @@
+package org.bndtools.runtime.controller.internal;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Properties;
+
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.bndtools.runtime.controller.IHandler;
+import org.bndtools.runtime.controller.IResponse;
+
+/**
+ * Adapts an IHandler to a Servlet.
+ * 
+ * @author kgilmer
+ *
+ */
+public class HandlerServletAdapter extends HttpServlet implements Servlet {
+	private static final long serialVersionUID = -9223098343374995024L;
+	private final IHandler handler;
+
+	public HandlerServletAdapter(IHandler handler) {
+		this.handler = handler;
+	}
+
+	/* (non-Javadoc)
+	 * @see javax.servlet.http.HttpServlet#doGet(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+	 */
+	protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+		Properties p = getProperties(req);
+		String[] qs = getQueryString(req);
+
+		respond(handler.handleGet(qs, p), resp);
+	}
+
+	/* (non-Javadoc)
+	 * @see javax.servlet.http.HttpServlet#doPost(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+	 */
+	protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+		Properties p = getProperties(req);
+		String[] qs = getQueryString(req);
+
+		//TODO: figure out what should be passed as 'upload' argument.
+		respond(handler.handlePost(qs, p, null, req.getInputStream()), resp);
+	}
+	
+	/* (non-Javadoc)
+	 * @see javax.servlet.http.HttpServlet#doDelete(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+	 */
+	protected void doDelete(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+		Properties p = getProperties(req);
+		String[] qs = getQueryString(req);
+
+		respond(handler.handleDelete(qs, p), resp);
+	}
+	
+	/* (non-Javadoc)
+	 * @see javax.servlet.http.HttpServlet#doPut(javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
+	 */
+	protected void doPut(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+		Properties p = getProperties(req);
+		String[] qs = getQueryString(req);
+
+		//TODO: figure out what should be passed as 'upload' argument.
+		respond(handler.handlePut(qs, p, null, req.getInputStream()), resp);
+	}
+
+	private String[] getQueryString(HttpServletRequest req) {
+		String[] q = new String[] {};
+
+		if (req.getQueryString() != null)
+			q = req.getQueryString().split("/");
+
+		return q;
+	}
+
+	/**
+	 * @param req
+	 * @return Properties for the request, or empty properties if null.
+	 */
+	private Properties getProperties(HttpServletRequest req) {
+		Properties p = new Properties();
+
+		if (req.getParameterMap() != null) {
+			for (Iterator i = req.getParameterMap().entrySet().iterator(); i.hasNext();) {
+				Entry e = (Entry) i.next();
+				p.put(e.getKey(), e.getValue());
+			}
+		}
+
+		return p;
+	}
+
+	/**
+	 * Given an IResponse and a HttpServletResponse, load the latter with data from the former, and then flush the buffer.
+	 * 
+	 * @param handlerResponse
+	 * @param servletResponse
+	 * @throws IOException
+	 */
+	private void respond(IResponse handlerResponse, HttpServletResponse servletResponse) throws IOException {
+
+		servletResponse.setContentType(handlerResponse.getMimeType());
+		servletResponse.setContentLength((int) handlerResponse.getContentLength());
+
+		InputStream input = handlerResponse.getData();
+		ServletOutputStream output = servletResponse.getOutputStream();
+
+		byte[] buf = new byte[8192];
+		while (true) {
+			int length = input.read(buf);
+			if (length < 0)
+				break;
+			output.write(buf, 0, length);
+		}
+
+		try {
+			input.close();
+		} catch (IOException ignore) {
+		}
+		try {
+			output.close();
+		} catch (IOException ignore) {
+		}
+		servletResponse.flushBuffer();
+	}
+}

--- a/bndtools.runtime.controller/src/org/bndtools/runtime/controller/internal/HttpServiceServer.java
+++ b/bndtools.runtime.controller/src/org/bndtools/runtime/controller/internal/HttpServiceServer.java
@@ -1,0 +1,83 @@
+package org.bndtools.runtime.controller.internal;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.bndtools.runtime.controller.IHandler;
+import org.bndtools.runtime.controller.IServer;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.ServiceReference;
+import org.osgi.service.http.HttpService;
+
+/**
+ * An IServer implementation that fronts an OSGi Http Service instance.
+ * 
+ * @author kgilmer
+ *
+ */
+public class HttpServiceServer implements IServer {
+	
+	private static final String DEFAULT_GLOBAL_PREFIX = "/btrc";
+	private final String globalPrefix;
+	private final BundleContext context;
+	private HttpService httpService;
+	private ServiceReference httpServiceReference;
+	private final Log log;
+	private final Map registrations;
+
+	public HttpServiceServer(BundleContext context, Log log) {
+		this.context = context;
+		this.log = log;
+		this.globalPrefix = DEFAULT_GLOBAL_PREFIX;
+		this.registrations = new HashMap();
+	}	
+
+	public void registerHandler(String prefix, IHandler handler) {
+		registrations.put(prefix, handler);
+	}
+
+	public void unregisterHandler(String prefix) {
+		registrations.remove(prefix);
+		
+		if (httpService != null)
+			httpService.unregister(globalPrefix + "/" + prefix);
+	}
+
+	public void start() throws IOException {
+		if (httpService != null || httpServiceReference != null)
+			throw new IllegalStateException("Server has already been started.");
+		
+		httpServiceReference = context.getServiceReference(HttpService.class.getName());
+		
+		if (httpServiceReference != null) {
+			httpService = (HttpService) context.getService(httpServiceReference);
+			
+			if (httpService == null)
+				throw new IOException("Unable to access Http Service");
+		} else {
+			throw new IOException("Unable to access Http Service");
+		}		
+		
+		for (Iterator i = registrations.keySet().iterator(); i.hasNext();) {
+			String prefix = (String) i.next();
+			IHandler handler = (IHandler) registrations.get(prefix);
+			try {
+				httpService.registerServlet(globalPrefix + "/" + prefix, new HandlerServletAdapter(handler), null, null);
+			} catch (Exception e) {
+				throw new IOException(e.getMessage());
+			}
+		}		
+	}
+
+	public void stop() throws IOException {
+		if (context != null && httpServiceReference != null)
+			context.ungetService(httpServiceReference);
+		
+		httpService = null;
+		httpServiceReference = null;
+		registrations.clear();
+	}
+
+}


### PR DESCRIPTION
Hi Neil, I'm considering moving from our BUG-specific SDK/BUG WS API to BndtoolsRuntimeController simply because it's clean and a nice isolation of the WS APIs.  I've added support to use an HTTP Service rather than NanoServer.  I've only tested doGet() but the code is there for all supported methods.

I saw in your docs that you had this as an unimplemented feature, so perhaps you are interested in pulling this...

cheers
ken
